### PR TITLE
[PG-3] Add Codacy badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # giraffe-proto
+ 
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/65a2c3c014fd4f11a90604aba1299375)](https://app.codacy.com/gh/namely/giraffe-proto/dashboard)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/65a2c3c014fd4f11a90604aba1299375)](https://app.codacy.com/gh/namely/giraffe-proto/dashboard)
 
 [![Build Status](https://travis-ci.org/namely/giraffe-proto.svg?branch=master)](https://travis-ci.org/namely/giraffe-proto)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
  
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/65a2c3c014fd4f11a90604aba1299375)](https://app.codacy.com/gh/namely/giraffe-proto/dashboard)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/65a2c3c014fd4f11a90604aba1299375)](https://app.codacy.com/gh/namely/giraffe-proto/dashboard)
-
 [![Build Status](https://travis-ci.org/namely/giraffe-proto.svg?branch=master)](https://travis-ci.org/namely/giraffe-proto)
 
 Protofiles for Giraffe, Namely's gRPC to GraphQL adapter


### PR DESCRIPTION

# What does this do?

This PR adds the Codacy badges to the README.md

# Why are we doing this?

The Codacy badges provide an easy at-a-glance view of the code quality and coverage for the repository and increase awareness of quality goals.

Please drop in on the #codacy-discussion channel in Slack if you have any questions.